### PR TITLE
Don't use references for passing small structs

### DIFF
--- a/core/include/shape.h
+++ b/core/include/shape.h
@@ -27,8 +27,7 @@ class Shape
 
     Vector2 get_origin();
 
-    void set_color(const Color&& color);
-    void set_color(const Color& color);
+    void set_color(const Color color);
 
   protected:
     Vector2       origin_;

--- a/core/shape.cpp
+++ b/core/shape.cpp
@@ -22,12 +22,7 @@ Vector2 Shape::get_origin()
     return origin_;
 }
 
-void Shape::set_color(const Color&& color)
-{
-    color_ = color;
-}
-
-void Shape::set_color(const Color& color)
+void Shape::set_color(const Color color)
 {
     color_ = color;
 }


### PR DESCRIPTION
Just a small cleanup.