### PR TITLE
Adding default shaders for textures

### DIFF
--- a/core/include/fixed_polygon_shape.h
+++ b/core/include/fixed_polygon_shape.h
@@ -180,7 +180,10 @@ void FixedPolygonShape<number_of_vertices>::draw()
 {
     normalize_coordinates();
 
-    std::int32_t color_location = glGetUniformLocation(RinvidGfx::get_default_shader(), "in_color");
+    glUseProgram(RinvidGfx::get_shape_default_shader());
+
+    std::int32_t color_location =
+        glGetUniformLocation(RinvidGfx::get_shape_default_shader(), "in_color");
     glUniform4f(color_location, color_.r, color_.g, color_.b, color_.a);
 }
 

--- a/core/include/rinvid_gfx.h
+++ b/core/include/rinvid_gfx.h
@@ -64,12 +64,20 @@ class RinvidGfx
     static void clear_screen(float r, float g, float b, float a);
 
     /**************************************************************************************************
-     * @brief Returns default shader handle. Should only used internally in Rinvid.
+     * @brief Returns default shape shader handle. Should only be used internally in Rinvid.
      *
-     * @return A handle to default shader
+     * @return An OpenGl handle to the shader
      *
      *************************************************************************************************/
-    static std::uint32_t get_default_shader();
+    static std::uint32_t get_shape_default_shader();
+
+    /**************************************************************************************************
+     * @brief Returns default texture shader handle. Should only be used internally in Rinvid.
+     *
+     * @return An OpenGl handle to the shader
+     *
+     *************************************************************************************************/
+    static std::uint32_t get_texture_default_shader();
 
     /**************************************************************************************************
      * @brief Returns screen width.
@@ -116,7 +124,8 @@ class RinvidGfx
     }
 
   private:
-    static std::uint32_t default_shader;
+    static std::uint32_t texture_default_shader_;
+    static std::uint32_t shape_default_shader_;
     static std::uint32_t width;
     static std::uint32_t height;
 };

--- a/core/rinvid_gfx.cpp
+++ b/core/rinvid_gfx.cpp
@@ -12,7 +12,29 @@
 namespace
 {
 
-static const char* vert_shader_source =
+static const char* texture_vert_shader_source =
+    "#version 330 core\n"
+    "layout (location = 0) in vec3 aPos;\n"
+    "layout (location = 1) in vec2 aTexCoord;\n"
+    "out vec2 TexCoord;\n"
+    "void main()\n"
+    "{\n"
+    "   gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
+    "   TexCoord = vec2(aTexCoord.x, aTexCoord.y);\n"
+    "}\0";
+
+static const char* texture_frag_shader_source =
+    "#version 330 core\n"
+    "out vec4 out_color;\n "
+    "uniform vec4 in_color;\n"
+    "uniform sampler2D texture1;\n"
+    "in vec2 TexCoord;\n"
+    "void main()\n"
+    "{\n"
+    "   out_color = texture(texture1, TexCoord);\n"
+    "}\n";
+
+static const char* shape_vert_shader_source =
     "#version 330 core\n"
     "layout (location = 0) in vec3 aPos;\n"
     "void main()\n"
@@ -20,7 +42,7 @@ static const char* vert_shader_source =
     "   gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
     "}\0";
 
-static const char* frag_shader_source =
+static const char* shape_frag_shader_source =
     "#version 330 core\n"
     "out vec4 out_color;\n "
     "uniform vec4 in_color;\n"
@@ -29,28 +51,44 @@ static const char* frag_shader_source =
     "   out_color = in_color;\n"
     "}\n";
 
-static void set_default_shader(std::uint32_t& default_shader_ref)
+static void init_default_shaders(std::uint32_t& shape_default_shader_handle,
+                                 std::uint32_t& texture_default_shader_handle)
 {
     std::uint32_t vert_shader;
     vert_shader = glCreateShader(GL_VERTEX_SHADER);
-    glShaderSource(vert_shader, 1, &vert_shader_source, nullptr);
+    glShaderSource(vert_shader, 1, &shape_vert_shader_source, nullptr);
     glCompileShader(vert_shader);
 
     std::uint32_t frag_shader;
     frag_shader = glCreateShader(GL_FRAGMENT_SHADER);
-    glShaderSource(frag_shader, 1, &frag_shader_source, nullptr);
+    glShaderSource(frag_shader, 1, &shape_frag_shader_source, nullptr);
     glCompileShader(frag_shader);
 
-    default_shader_ref = glCreateProgram();
+    shape_default_shader_handle = glCreateProgram();
 
-    glAttachShader(default_shader_ref, vert_shader);
-    glAttachShader(default_shader_ref, frag_shader);
-    glLinkProgram(default_shader_ref);
+    glAttachShader(shape_default_shader_handle, vert_shader);
+    glAttachShader(shape_default_shader_handle, frag_shader);
+    glLinkProgram(shape_default_shader_handle);
 
     glDeleteShader(vert_shader);
     glDeleteShader(frag_shader);
 
-    glUseProgram(default_shader_ref);
+    vert_shader = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vert_shader, 1, &texture_vert_shader_source, nullptr);
+    glCompileShader(vert_shader);
+
+    frag_shader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(frag_shader, 1, &texture_frag_shader_source, nullptr);
+    glCompileShader(frag_shader);
+
+    texture_default_shader_handle = glCreateProgram();
+
+    glAttachShader(texture_default_shader_handle, vert_shader);
+    glAttachShader(texture_default_shader_handle, frag_shader);
+    glLinkProgram(texture_default_shader_handle);
+
+    glDeleteShader(vert_shader);
+    glDeleteShader(frag_shader);
 }
 
 } // namespace
@@ -58,13 +96,14 @@ static void set_default_shader(std::uint32_t& default_shader_ref)
 namespace rinvid
 {
 
-std::uint32_t RinvidGfx::default_shader{};
+std::uint32_t RinvidGfx::shape_default_shader_{};
+std::uint32_t RinvidGfx::texture_default_shader_{};
 std::uint32_t RinvidGfx::width{};
 std::uint32_t RinvidGfx::height{};
 
 void RinvidGfx::init()
 {
-    set_default_shader(RinvidGfx::default_shader);
+    init_default_shaders(RinvidGfx::shape_default_shader_, RinvidGfx::texture_default_shader_);
 }
 
 void RinvidGfx::set_viewport(std::int32_t x, std::int32_t y, std::int32_t width,
@@ -81,9 +120,14 @@ void RinvidGfx::clear_screen(float r, float g, float b, float a)
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 }
 
-std::uint32_t RinvidGfx::get_default_shader()
+std::uint32_t RinvidGfx::get_shape_default_shader()
 {
-    return default_shader;
+    return shape_default_shader_;
+}
+
+std::uint32_t RinvidGfx::get_texture_default_shader()
+{
+    return texture_default_shader_;
 }
 
 std::uint32_t RinvidGfx::get_width()


### PR DESCRIPTION
For now, we are limited to only 2 default sets of shaders. One set for shapes, other one for textures (sprites). This will obviously need to be refactored once we start implementing cool effects and allow users to use their own shaders, but until I learn more about shaders, this is a temporary solution.