### PR TITLE
Add -Werror and warning flags to build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt='-std=c++17'

--- a/core/BUILD
+++ b/core/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "include/texture.h",
         "include/triangle_shape.h",
     ],
+    copts = ["-Werror -Wall -Wextra -pedantic"],
     linkopts = ["-lsfml-window -lsfml-system -lGL"],
     visibility = ["//examples:__subpackages__"],
     deps = ["//util"],

--- a/core/include/sprite.h
+++ b/core/include/sprite.h
@@ -99,7 +99,7 @@ class Sprite
     template <typename T>
     std::vector<Rect> get_regions(std::initializer_list<T> region_indices)
     {
-        static_assert(std::is_integral<T>::value == true);
+        static_assert(std::is_integral<T>::value == true, "T must be of integral type");
 
         std::vector<Rect> regions{};
 

--- a/examples/primitive_shapes/BUILD
+++ b/examples/primitive_shapes/BUILD
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "primitive_shapes",
     srcs = ["main.cpp"],
+    copts = ["-Werror -Wall -Wextra -pedantic"],
     linkopts = ["-lsfml-window -lsfml-system"],
     deps = [
         "//core:rinvid_core",

--- a/examples/sprites/BUILD
+++ b/examples/sprites/BUILD
@@ -3,6 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "sprites",
     srcs = ["main.cpp"],
+    copts = ["-Werror -Wall -Wextra -pedantic"],
     data = [":resources/trashbot.png"],
     linkopts = ["-lsfml-window -lsfml-system"],
     deps = [

--- a/examples/testing_grounds/BUILD
+++ b/examples/testing_grounds/BUILD
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "test",
     srcs = ["main.cpp"],
-    copts = ["-std=c++1z -Werror -Wall -Wextra -pedantic"],
+    copts = ["-Werror -Wall -Wextra -pedantic"],
     data = [
         ":resources/clck.png",
         ":resources/logo.png",

--- a/examples/testing_grounds/BUILD
+++ b/examples/testing_grounds/BUILD
@@ -3,7 +3,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 cc_binary(
     name = "test",
     srcs = ["main.cpp"],
-    copts = ["-std=c++1z"],
+    copts = ["-std=c++1z -Werror -Wall -Wextra -pedantic"],
     data = [
         ":resources/clck.png",
         ":resources/logo.png",

--- a/util/BUILD
+++ b/util/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "include/vector2.h",
         "include/vector3.h",
     ],
+    copts = ["-Werror -Wall -Wextra -pedantic"],
     visibility = [
         "//core:__subpackages__",
         "//examples:__subpackages__",


### PR DESCRIPTION
Adding -Werror and warning (-Wall, -Wextra, -pedantic) flags should hopefully help us write better and cleaner code.
Also using single C++ standard for the whole workspace.