### PR TITLE
Add scale method to Rect struct

### DIFF
--- a/util/include/rect.h
+++ b/util/include/rect.h
@@ -19,6 +19,28 @@ namespace rinvid
 
 struct Rect
 {
+    /**************************************************************************************************
+     * @brief Scales rect
+     *
+     * This is mainly intended to use together with bounding_rect() method on objects that have it,
+     * for collision detection, to adjust the size of the bounding box.
+     *
+     * @param scale_factor how much to scale rect (e.g. 0.5 means rect will be half of its current
+     * size)
+     *
+     * @return Returns reference to itself. Handy for chaining function calls.
+     *
+     *************************************************************************************************/
+    Rect& scale(float scale_factor)
+    {
+        position.x += (((1.0F - scale_factor) * width) / 2.0F);
+        position.y += (((1.0F - scale_factor) * height) / 2.0F);
+        width *= scale_factor;
+        height *= scale_factor;
+
+        return *this;
+    }
+
     Vector2<float> position;
     std::int32_t   width;
     std::int32_t   height;


### PR DESCRIPTION
Mainly intended to make collision detection with bounding_rect() more
usefull by allowing correction of size of bounding_rect(). The best
solution for collision detection and general physics is still to use
some dedicated engine for it, this is just a handy util for people that
don't need full blown physics engine but need some basic collision
detection.