### PR TITLE
Prevent texture wrapping

### DIFF
--- a/core/texture.cpp
+++ b/core/texture.cpp
@@ -51,8 +51,8 @@ Texture::Texture(const char* file_name)
 
     GL_CALL(glGenTextures(1, &texture_id_));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture_id_));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
     GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width_, height_, 0, GL_RGBA, GL_UNSIGNED_BYTE,


### PR DESCRIPTION
This is a temporary solution to issue noticed in screens example (the character texture was wrapping a bit during animation), this might need to be handled differently for different cases but until such need arises, it can stay like this.