### PR TITLE
Use pixels per second unit for movement in remaining examples

### DIFF
--- a/examples/primitive_shapes/main.cpp
+++ b/examples/primitive_shapes/main.cpp
@@ -58,8 +58,6 @@ void ShapesScreen::create()
 
 void ShapesScreen::update(double delta_time)
 {
-    (void)delta_time;
-
     rinvid::RinvidGfx::clear_screen(0.2F, 0.4F, 0.4F, 1.0F);
 
     vertical_delta   = 0.0F;
@@ -84,7 +82,8 @@ void ShapesScreen::update(double delta_time)
 
     handle_movement(vertical_delta, horizontal_delta);
 
-    current_shape->move(rinvid::Vector2<float>{horizontal_delta, vertical_delta});
+    current_shape->move(rinvid::Vector2<float>{horizontal_delta * static_cast<float>(delta_time),
+                                               vertical_delta * static_cast<float>(delta_time)});
 
     triangle.draw();
     quad.draw();
@@ -109,22 +108,22 @@ void ShapesScreen::handle_movement(float& vertical_delta, float& horizontal_delt
     if (Keyboard::is_key_pressed(Keyboard::Key::D) ||
         Keyboard::is_key_pressed(Keyboard::Key::Right))
     {
-        horizontal_delta += 5.0F;
+        horizontal_delta += 500.0F;
     }
 
     if (Keyboard::is_key_pressed(Keyboard::Key::A) || Keyboard::is_key_pressed(Keyboard::Key::Left))
     {
-        horizontal_delta -= 5.0F;
+        horizontal_delta -= 500.0F;
     }
 
     if (Keyboard::is_key_pressed(Keyboard::Key::W) || Keyboard::is_key_pressed(Keyboard::Key::Up))
     {
-        vertical_delta -= 5.0F;
+        vertical_delta -= 500.0F;
     }
 
     if (Keyboard::is_key_pressed(Keyboard::Key::S) || Keyboard::is_key_pressed(Keyboard::Key::Down))
     {
-        vertical_delta += 5.0F;
+        vertical_delta += 500.0F;
     }
 }
 

--- a/examples/sprites/main.cpp
+++ b/examples/sprites/main.cpp
@@ -95,7 +95,7 @@ void SpritesScreen::update(double delta_time)
         robot_sprite.play(current_animation_state);
     }
 
-    robot_sprite.move(rinvid::Vector2<float>{horizontal_delta, 0});
+    robot_sprite.move(rinvid::Vector2<float>{horizontal_delta * static_cast<float>(delta_time), 0});
 }
 
 void SpritesScreen::destroy()
@@ -107,12 +107,12 @@ void SpritesScreen::handle_inputs(float& horizontal_delta)
     if (Keyboard::is_key_pressed(Keyboard::Key::D) ||
         Keyboard::is_key_pressed(Keyboard::Key::Right))
     {
-        horizontal_delta += 4.8F;
+        horizontal_delta += 480.0F;
     }
 
     if (Keyboard::is_key_pressed(Keyboard::Key::A) || Keyboard::is_key_pressed(Keyboard::Key::Left))
     {
-        horizontal_delta -= 4.8F;
+        horizontal_delta -= 480.0F;
     }
 }
 


### PR DESCRIPTION
This should make examples more uniform. 