### PR TITLE
Core: Fix light position to the world coords

### DIFF
--- a/core/camera.cpp
+++ b/core/camera.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022, Filip Vasiljevic
+ * Copyright (c) 2022 - 2023, Filip Vasiljevic
  * All rights reserved.
  *
  * This file is subject to the terms and conditions of the BSD 2-Clause
@@ -29,6 +29,11 @@ void Camera::move(const Vector2<float> move_vector)
 {
     camera_pos_ += move_vector.y * camera_up_;
     camera_pos_ += glm::normalize(glm::cross(camera_front_, camera_up_)) * move_vector.x;
+}
+
+Vector2<float> Camera::get_pos() const
+{
+    return Vector2<float>{camera_pos_.x, camera_pos_.y};
 }
 
 } // namespace rinvid

--- a/core/include/camera.h
+++ b/core/include/camera.h
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2022, Filip Vasiljevic
+ * Copyright (c) 2022 - 2023, Filip Vasiljevic
  * All rights reserved.
  *
  * This file is subject to the terms and conditions of the BSD 2-Clause
@@ -43,6 +43,14 @@ class Camera
      *
      *************************************************************************************************/
     void move(const Vector2<float> move_vector);
+
+    /**************************************************************************************************
+     * @brief Returns current camera position.
+     *
+     * @return camera position.
+     *
+     *************************************************************************************************/
+    Vector2<float> get_pos() const;
 
   private:
     glm::vec3 camera_pos_;

--- a/core/include/light.h
+++ b/core/include/light.h
@@ -85,6 +85,14 @@ class Light
      *************************************************************************************************/
     void switch_it(bool on);
 
+    /**************************************************************************************************
+     * @brief Updates the light, should be called every frame.
+     *
+     * @param camera_pos Position of the camera if there is any.
+     *
+     *************************************************************************************************/
+    void update(Vector2<float> camera_pos = {0.0F, 0.0F});
+
   private:
     /**************************************************************************************************
      * @brief Helper function to remap a floating point value from one range to another.

--- a/core/light.cpp
+++ b/core/light.cpp
@@ -170,4 +170,22 @@ void Light::switch_it(bool on)
     shape_shader.set_bool("light_active[" + std::to_string(ordinal_) + "]", on);
 }
 
+/// @todo This is bullshit, this should probably be handled in the shader and update method should
+/// not exist, revisit this later.
+void Light::update(Vector2<float> camera_pos)
+{
+    Vector2<float> position = position_;
+    position.x -= camera_pos.x;
+    position.y -= camera_pos.y;
+    const auto texture_shader = RinvidGfx::get_texture_default_shader();
+    texture_shader.use();
+    texture_shader.set_float2("light_pos[" + std::to_string(ordinal_) + "]", position.x,
+                              RinvidGfx::get_height() - position.y);
+
+    const auto shape_shader = RinvidGfx::get_shape_default_shader();
+    shape_shader.use();
+    shape_shader.set_float2("light_pos[" + std::to_string(ordinal_) + "]", position.x,
+                            RinvidGfx::get_height() - position.y);
+}
+
 } // namespace rinvid

--- a/examples/testing_grounds/main.cpp
+++ b/examples/testing_grounds/main.cpp
@@ -146,6 +146,8 @@ void TestingGrounds::update(double delta_time)
 
     camera.update();
 
+    light_mid.update(camera.get_pos());
+
     background_sprite.draw();
 
     triangle.draw();


### PR DESCRIPTION
-Instead of light always being relative to the screen, fix it to the world coordinates.
-If light needs to be relative to screen, just don't pass camera position to the light's update method.