### PR TITLE
Build: Use ninja instead of make for building

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "extern/stb"]
 	path = extern/stb
 	url = https://github.com/nothings/stb.git
+[submodule "extern/googletest"]
+	path = extern/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ project("rinvid")
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(RINVID_BUILD_TESTS "Build Rinvid tests" ON)
+set(RINVID_GTEST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/googletest"
+    CACHE PATH "Path to a local GoogleTest source checkout")
+
 add_library(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
@@ -54,4 +58,6 @@ add_subdirectory(examples/shaders)
 add_subdirectory(examples/sprites)
 add_subdirectory(examples/testing_grounds)
 
-add_subdirectory(tests)
+if(RINVID_BUILD_TESTS)
+  add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Rinvid is a small framework for 2D games and multimedia applications development
 ### Ubuntu
 
 These are instructions for Ubuntu 20.04, it would probably work on other Debian based distros:  
-First, you will need to install  SFML, Gtest and Freetype.  
+First, you will need to install SFML, Ninja and Freetype.  
 ```shell
 sudo apt install cmake
+sudo apt install ninja-build
 sudo apt install libsfml-dev  
-sudo apt install libgtest-dev  
 sudo apt install libfreetype-dev  
 ```
 Note that Freetpye headers must be in root include directory, and not in any new one. To make sure that's the case, you can run:  
@@ -21,12 +21,12 @@ Note that Freetpye headers must be in root include directory, and not in any new
 cd /usr/include/freetype2  
 sudo cp -r * ../  
 ```
-After that, clone the repo (run `git submodule update --init --recursive` after cloning to initiate submodules) and then use CMake to build the lib and all examples:  
+After that, clone the repo (run `git submodule update --init --recursive` after cloning to initiate submodules) and then use CMake and Ninja to build the lib and all examples:  
 ```shell    
 mkdir build
 cd build
-cmake ..
-make all -j8
+cmake -S .. -B . -G Ninja
+ninja all
 ```
 
 ### Windows 10
@@ -36,31 +36,42 @@ What you need to build Rinvid on Windows 10:
    1. [MinGW](https://www.mingw-w64.org/)  
    2. [MSYS](https://www.msys2.org/)
    3. [SFML](https://www.sfml-dev.org/)  
-   4. [gtest](https://github.com/google/googletest)  
+   4. [gtest](https://github.com/google/googletest) source checkout
    5. [Freetype](http://freetype.org/)  
+   6. [Ninja](https://ninja-build.org/)
 
 #### Development environment setup
 
 1. Install [MSYS2](https://www.msys2.org/) - following all steps will also install MinGW via `pacman`
-2. Additionally, install CMake, SFML and gtest via `pacman` by executing the following commands in the MSYS2 terminal:
+2. Additionally, install CMake, Ninja, SFML and Freetype via `pacman` by executing the following commands in the MSYS2 terminal:
 ```shell
 pacman -Syu
 pacman -S mingw-w64-x86_64-cmake
+pacman -S mingw-w64-x86_64-ninja
 pacman -S mingw-w64-x86_64-sfml
-pacman -S mingw-w64-x86_64-gtest
 pacman -S mingw-w64-x86_64-freetype
 ```
-4. Pull external dependencies by running the following command from the root of the project:
+3. Pull external dependencies by running the following command from the root of the project:
 ```shell
 git submodule update --init --recursive
 ```
+4. Clone GoogleTest source into `extern/googletest` from the root of the Rinvid project:
+```shell
+git clone https://github.com/google/googletest.git extern/googletest
+```
+You can also point CMake to a different checkout with `-DRINVID_GTEST_SOURCE_DIR=/absolute/path/to/googletest`.
 
-From MSYS2 terminal, you can run the standard cmake build procedure: 
+From the MinGW64 MSYS2 terminal, you can run the Ninja build procedure: 
 ```shell    
 mkdir build
 cd build
-cmake ..
-make all -j8
+/mingw64/bin/cmake -S .. -B . -G Ninja
+ninja all
+```
+
+To build without tests, configure with:
+```shell
+/mingw64/bin/cmake -S .. -B . -G Ninja -DRINVID_BUILD_TESTS=OFF
 ```
 
 ## External libraries used by Rinvid

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,23 @@
+if(NOT EXISTS "${RINVID_GTEST_SOURCE_DIR}/CMakeLists.txt")
+  message(
+    FATAL_ERROR
+      "GoogleTest source not found.\n"
+      "Expected a checkout at: ${RINVID_GTEST_SOURCE_DIR}\n"
+      "Clone or unpack googletest there, or configure with:\n"
+      "  -DRINVID_GTEST_SOURCE_DIR=/absolute/path/to/googletest")
+endif()
+
+set(BUILD_GMOCK OFF CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+add_subdirectory("${RINVID_GTEST_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/googletest"
+                 EXCLUDE_FROM_ALL)
+
 file(GLOB_RECURSE EXAMPLE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 
 add_executable(rinvid_test WIN32 ${EXAMPLE_SOURCES})
 
 target_include_directories(rinvid_test PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(rinvid_test PRIVATE rinvid
-                                        gtest)
+target_link_libraries(rinvid_test PRIVATE rinvid gtest)
 target_compile_options(rinvid_test PRIVATE -Werror -Wall -Wextra -pedantic
                                                -O3)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,9 @@
 # Tests
 
-Contains all the tests. Uses gtest.
+Contains all the tests. Uses GoogleTest built from source as part of the CMake build.
+
+To skip building tests entirely, configure with:
+
+```shell
+-DRINVID_BUILD_TESTS=OFF
+```


### PR DESCRIPTION
-Using make was creating issues on windows
-Build googletest from source - this helps avoid
issues with compiler compatibility