### PR TITLE
Core: Refactor Sprite and Texture

### DIFF
--- a/core/sprite.cpp
+++ b/core/sprite.cpp
@@ -7,6 +7,8 @@
  * repository for more details.
  **********************************************************************/
 
+#include <rinvid/core/rinvid_gfx.h>
+#include <rinvid/core/rinvid_gl.h>
 #include <rinvid/core/sprite.h>
 
 namespace rinvid
@@ -24,10 +26,12 @@ Sprite::Sprite(Texture* texture, std::int32_t width, std::int32_t height, Vector
                Vector2f texture_offset)
     : sprite_animation_{}, texture_{texture}, texture_offset_{texture_offset}, opacity_{1.0F}
 {
-    width_    = width;
-    height_   = height;
-    position_ = top_left;
-    texture_->update_vertices(texture_offset_, width_, height_);
+    setup(texture, width, height, top_left, texture_offset);
+}
+
+Sprite::~Sprite()
+{
+    release_gl_resources();
 }
 
 void Sprite::draw()
@@ -48,6 +52,11 @@ void Sprite::draw(double delta_time)
 
 void Sprite::draw(double delta_time, const Shader shader)
 {
+    if (texture_ == nullptr)
+    {
+        return;
+    }
+
     origin_.x = position_.x + width_ / 2;
     origin_.y = position_.y + height_ / 2;
 
@@ -62,10 +71,18 @@ void Sprite::draw(double delta_time, const Shader shader)
         offset.x += texture_region.position.x;
         offset.y += texture_region.position.y;
 
-        texture_->update_vertices(offset, width, height);
+        update_vertices(offset, width, height);
     }
 
-    texture_->draw(get_transform(), shader, opacity_);
+    ensure_vertex_buffer_initialized();
+
+    shader.use();
+    RinvidGfx::update_mvp_matrix(get_transform(), shader.get_id());
+    shader.set_float("opacity", opacity_);
+
+    texture_->bind();
+    GL_CALL(glBindVertexArray(vertex_array_object_));
+    GL_CALL(glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0));
 }
 
 void Sprite::move(const Vector2f move_vector)
@@ -122,7 +139,7 @@ void Sprite::setup(Texture* texture, std::int32_t width, std::int32_t height, Ve
     position_       = top_left;
     texture_offset_ = texture_offset;
 
-    texture_->update_vertices(texture_offset_, width_, height_);
+    update_vertices(texture_offset_, width_, height_);
 }
 
 void Sprite::set_opacity(float transparency)
@@ -133,6 +150,109 @@ void Sprite::set_opacity(float transparency)
 SpriteAnimation& Sprite::get_animation()
 {
     return sprite_animation_;
+}
+
+void Sprite::ensure_vertex_buffer_initialized()
+{
+    if (vertex_array_object_ == 0U)
+    {
+        init_vertex_buffer();
+    }
+}
+
+void Sprite::init_vertex_buffer()
+{
+    GL_CALL(glGenVertexArrays(1, &vertex_array_object_));
+    GL_CALL(glGenBuffers(1, &vertex_buffer_object_));
+    GL_CALL(glGenBuffers(1, &element_buffer_object_));
+
+    GL_CALL(glBindVertexArray(vertex_array_object_));
+
+    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_object_));
+    GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(gl_vertices_), gl_vertices_, GL_DYNAMIC_DRAW));
+
+    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, element_buffer_object_));
+    GL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices_), indices_, GL_STATIC_DRAW));
+
+    // Position attribute
+    GL_CALL(glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0));
+    GL_CALL(glEnableVertexAttribArray(0));
+
+    // Texture coordinate attribute
+    GL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
+                                  (void*)(3 * sizeof(float))));
+    GL_CALL(glEnableVertexAttribArray(1));
+}
+
+void Sprite::release_gl_resources()
+{
+    if (element_buffer_object_ != 0U)
+    {
+        GL_CALL(glDeleteBuffers(1, &element_buffer_object_));
+        element_buffer_object_ = 0U;
+    }
+
+    if (vertex_buffer_object_ != 0U)
+    {
+        GL_CALL(glDeleteBuffers(1, &vertex_buffer_object_));
+        vertex_buffer_object_ = 0U;
+    }
+
+    if (vertex_array_object_ != 0U)
+    {
+        GL_CALL(glDeleteVertexArrays(1, &vertex_array_object_));
+        vertex_array_object_ = 0U;
+    }
+}
+
+void Sprite::update_vertices(Vector2f offset, std::uint32_t width, std::uint32_t height)
+{
+    if (texture_ == nullptr)
+    {
+        return;
+    }
+
+    ensure_vertex_buffer_initialized();
+
+    // Make center of texture (0, 0) for simplicity.
+    Vector2f top_left{};
+    top_left.x = 0.0F - (width / 2.0F);
+    top_left.y = 0.0F - (height / 2.0F);
+
+    // Top left
+    gl_vertices_[0] = top_left.x;
+    gl_vertices_[1] = top_left.y;
+    gl_vertices_[2] = 0.0F;
+    gl_vertices_[3] = offset.x / static_cast<float>(texture_->width_);
+    gl_vertices_[4] = offset.y / static_cast<float>(texture_->height_);
+
+    // Top right
+    gl_vertices_[5] = top_left.x + width;
+    gl_vertices_[6] = top_left.y;
+    gl_vertices_[7] = 0.0F;
+    gl_vertices_[8] = static_cast<float>(width) / static_cast<float>(texture_->width_) +
+                      offset.x / static_cast<float>(texture_->width_);
+    gl_vertices_[9] = offset.y / static_cast<float>(texture_->height_);
+
+    // Bottom right
+    gl_vertices_[10] = top_left.x + width;
+    gl_vertices_[11] = top_left.y + height;
+    gl_vertices_[12] = 0.0F;
+    gl_vertices_[13] = static_cast<float>(width) / static_cast<float>(texture_->width_) +
+                       offset.x / static_cast<float>(texture_->width_);
+    gl_vertices_[14] = static_cast<float>(height) / static_cast<float>(texture_->height_) +
+                       offset.y / static_cast<float>(texture_->height_);
+
+    // Bottom left
+    gl_vertices_[15] = top_left.x;
+    gl_vertices_[16] = top_left.y + height;
+    gl_vertices_[17] = 0.0F;
+    gl_vertices_[18] = offset.x / static_cast<float>(texture_->width_);
+    gl_vertices_[19] = static_cast<float>(height) / static_cast<float>(texture_->height_) +
+                       offset.y / static_cast<float>(texture_->height_);
+
+    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_object_));
+    GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(gl_vertices_), gl_vertices_, GL_DYNAMIC_DRAW));
 }
 
 } // namespace rinvid

--- a/core/texture.cpp
+++ b/core/texture.cpp
@@ -7,13 +7,9 @@
  * repository for more details.
  **********************************************************************/
 
-#include <iostream>
-#include <iterator>
+#include <string>
 #include <vector>
 
-#include <glm/gtc/type_ptr.hpp>
-
-#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/core/rinvid_gl.h>
 #include <rinvid/core/texture.h>
 #include <rinvid/util/error_handler.h>
@@ -29,49 +25,10 @@ void Texture::release_gl_resources()
         GL_CALL(glDeleteTextures(1, &texture_id_));
         texture_id_ = 0;
     }
-
-    if (element_buffer_object_ != 0)
-    {
-        GL_CALL(glDeleteBuffers(1, &element_buffer_object_));
-        element_buffer_object_ = 0;
-    }
-
-    if (vertex_buffer_obecjt_ != 0)
-    {
-        GL_CALL(glDeleteBuffers(1, &vertex_buffer_obecjt_));
-        vertex_buffer_obecjt_ = 0;
-    }
-
-    if (vertex_array_object_ != 0)
-    {
-        GL_CALL(glDeleteVertexArrays(1, &vertex_array_object_));
-        vertex_array_object_ = 0;
-    }
 }
 
 Texture::Texture(const char* file_name)
 {
-    GL_CALL(glGenVertexArrays(1, &vertex_array_object_));
-    GL_CALL(glGenBuffers(1, &vertex_buffer_obecjt_));
-    GL_CALL(glGenBuffers(1, &element_buffer_object_));
-
-    GL_CALL(glBindVertexArray(vertex_array_object_));
-
-    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_obecjt_));
-    GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(gl_vertices_), gl_vertices_, GL_STATIC_DRAW));
-
-    GL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, element_buffer_object_));
-    GL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices_), indices_, GL_STATIC_DRAW));
-
-    // Position attribute
-    GL_CALL(glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0));
-    GL_CALL(glEnableVertexAttribArray(0));
-
-    // Texture coordinate attribute
-    GL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float),
-                                  (void*)(3 * sizeof(float))));
-    GL_CALL(glEnableVertexAttribArray(1));
-
     std::vector<std::uint8_t> image_data{};
     bool                      result = load_image(file_name, image_data, width_, height_);
     if (result == false)
@@ -92,22 +49,13 @@ Texture::Texture(const char* file_name)
 
 Texture::Texture(Texture&& other)
 {
-    this->width_                 = other.width_;
-    this->height_                = other.height_;
-    this->vertex_array_object_   = other.vertex_array_object_;
-    this->vertex_buffer_obecjt_  = other.vertex_buffer_obecjt_;
-    this->element_buffer_object_ = other.element_buffer_object_;
-    this->texture_id_            = other.texture_id_;
+    width_      = other.width_;
+    height_     = other.height_;
+    texture_id_ = other.texture_id_;
 
-    std::copy(std::begin(other.gl_vertices_), std::end(other.gl_vertices_),
-              std::begin(this->gl_vertices_));
-
-    other.vertex_array_object_   = 0;
-    other.vertex_buffer_obecjt_  = 0;
-    other.element_buffer_object_ = 0;
-    other.texture_id_            = 0;
-    other.width_                 = 0;
-    other.height_                = 0;
+    other.texture_id_ = 0;
+    other.width_      = 0;
+    other.height_     = 0;
 }
 
 Texture& Texture::operator=(Texture&& other)
@@ -119,22 +67,13 @@ Texture& Texture::operator=(Texture&& other)
 
     release_gl_resources();
 
-    this->width_                 = other.width_;
-    this->height_                = other.height_;
-    this->vertex_array_object_   = other.vertex_array_object_;
-    this->vertex_buffer_obecjt_  = other.vertex_buffer_obecjt_;
-    this->element_buffer_object_ = other.element_buffer_object_;
-    this->texture_id_            = other.texture_id_;
+    width_      = other.width_;
+    height_     = other.height_;
+    texture_id_ = other.texture_id_;
 
-    std::copy(std::begin(other.gl_vertices_), std::end(other.gl_vertices_),
-              std::begin(this->gl_vertices_));
-
-    other.vertex_array_object_   = 0;
-    other.vertex_buffer_obecjt_  = 0;
-    other.element_buffer_object_ = 0;
-    other.texture_id_            = 0;
-    other.width_                 = 0;
-    other.height_                = 0;
+    other.texture_id_ = 0;
+    other.width_      = 0;
+    other.height_     = 0;
 
     return *this;
 }
@@ -144,58 +83,9 @@ Texture::~Texture()
     release_gl_resources();
 }
 
-void Texture::draw(const glm::mat4& transform, const Shader shader, float opacity)
+void Texture::bind() const
 {
-    shader.use();
-    RinvidGfx::update_mvp_matrix(transform, shader.get_id());
-    shader.set_float("opacity", opacity);
-
     GL_CALL(glBindTexture(GL_TEXTURE_2D, texture_id_));
-    GL_CALL(glBindVertexArray(vertex_array_object_));
-    GL_CALL(glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0));
-}
-
-void Texture::update_vertices(Vector2f offset, std::uint32_t width, std::uint32_t height)
-{
-    // Make center of texture (0, 0) for simplicity
-    Vector2f top_left{};
-    top_left.x = 0.0F - (width / 2.0F);
-    top_left.y = 0.0F - (height / 2.0F);
-
-    // Top left
-    gl_vertices_[0] = top_left.x;
-    gl_vertices_[1] = top_left.y;
-    gl_vertices_[2] = 0.0F;
-    gl_vertices_[3] = offset.x / static_cast<float>(width_);
-    gl_vertices_[4] = offset.y / static_cast<float>(height_);
-
-    // Top right
-    gl_vertices_[5] = top_left.x + width;
-    gl_vertices_[6] = top_left.y;
-    gl_vertices_[7] = 0.0F;
-    gl_vertices_[8] = static_cast<float>(width) / static_cast<float>(width_) +
-                      offset.x / static_cast<float>(width_);
-    gl_vertices_[9] = offset.y / static_cast<float>(height_);
-
-    // Bottom right
-    gl_vertices_[10] = top_left.x + width;
-    gl_vertices_[11] = top_left.y + height;
-    gl_vertices_[12] = 0.0F;
-    gl_vertices_[13] = static_cast<float>(width) / static_cast<float>(width_) +
-                       offset.x / static_cast<float>(width_);
-    gl_vertices_[14] = static_cast<float>(height) / static_cast<float>(height_) +
-                       offset.y / static_cast<float>(height_);
-
-    // Bottom left
-    gl_vertices_[15] = top_left.x;
-    gl_vertices_[16] = top_left.y + height;
-    gl_vertices_[17] = 0.0F;
-    gl_vertices_[18] = offset.x / static_cast<float>(width_);
-    gl_vertices_[19] = static_cast<float>(height) / static_cast<float>(height_) +
-                       offset.y / static_cast<float>(height_);
-
-    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_obecjt_));
-    GL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(gl_vertices_), gl_vertices_, GL_STATIC_DRAW));
 }
 
 } // namespace rinvid

--- a/examples/physix/main.cpp
+++ b/examples/physix/main.cpp
@@ -8,6 +8,7 @@
  **********************************************************************/
 
 #include <rinvid/core/application.h>
+#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/core/screen.h>
 #include <rinvid/core/sprite.h>
 #include <rinvid/core/sprite_object.h>

--- a/examples/screens/level_one.cpp
+++ b/examples/screens/level_one.cpp
@@ -11,6 +11,7 @@
 
 #include "level_one.h"
 #include "level_two.h"
+#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/system/keyboard.h>
 
 using namespace rinvid::system;

--- a/examples/screens/level_two.cpp
+++ b/examples/screens/level_two.cpp
@@ -8,6 +8,7 @@
  **********************************************************************/
 
 #include "level_two.h"
+#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/system/keyboard.h>
 #include <rinvid/util/vector2.h>
 

--- a/gui/button.cpp
+++ b/gui/button.cpp
@@ -11,6 +11,7 @@
 
 #include <SFML/Window.hpp>
 
+#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/gui/button.h>
 #include <rinvid/system/mouse.h>
 #include <rinvid/util/collision_detection.h>

--- a/include/rinvid/core/sprite.h
+++ b/include/rinvid/core/sprite.h
@@ -10,6 +10,8 @@
 #ifndef INCLUDE_RINVID_CORE_SPRITE_H
 #define INCLUDE_RINVID_CORE_SPRITE_H
 
+#include <cstdint>
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
@@ -40,9 +42,35 @@ class Sprite : public virtual RectPOD, public Transformable, public DrawableAnim
      *************************************************************************************************/
     Sprite();
 
-    virtual ~Sprite()
-    {
-    }
+    /**************************************************************************************************
+     * @brief Copy constructor deleted.
+     *
+     *************************************************************************************************/
+    Sprite(const Sprite& other) = delete;
+
+    /**************************************************************************************************
+     * @brief Copy assignment operator deleted.
+     *
+     *************************************************************************************************/
+    Sprite& operator=(const Sprite& other) = delete;
+
+    /**************************************************************************************************
+     * @brief Move constructor deleted.
+     *
+     *************************************************************************************************/
+    Sprite(Sprite&& other) = delete;
+
+    /**************************************************************************************************
+     * @brief Move assignment operator deleted.
+     *
+     *************************************************************************************************/
+    Sprite& operator=(Sprite&& other) = delete;
+
+    /**************************************************************************************************
+     * @brief Destructor.
+     *
+     *************************************************************************************************/
+    virtual ~Sprite();
 
     /**************************************************************************************************
      * @brief Sprite constructor.
@@ -147,9 +175,26 @@ class Sprite : public virtual RectPOD, public Transformable, public DrawableAnim
     SpriteAnimation sprite_animation_;
 
   private:
+    void ensure_vertex_buffer_initialized();
+    void init_vertex_buffer();
+    void release_gl_resources();
+    void update_vertices(Vector2f offset, std::uint32_t width, std::uint32_t height);
+
     Texture* texture_;
     Vector2f texture_offset_;
     float    opacity_;
+
+    std::uint32_t vertex_array_object_{};
+    std::uint32_t vertex_buffer_object_{};
+    std::uint32_t element_buffer_object_{};
+
+    // There are four vertices with 5 elements each, elements are: x, y, z coordinate and x and y
+    // texture coordinate, hence 4 * 5.
+    float               gl_vertices_[4 * 5]{};
+    const std::uint32_t indices_[6] = {
+        0, 1, 3, // first triangle
+        1, 2, 3  // second triangle
+    };
 };
 
 } // namespace rinvid

--- a/include/rinvid/core/texture.h
+++ b/include/rinvid/core/texture.h
@@ -12,12 +12,6 @@
 
 #include <cstdint>
 
-#include <glm/mat4x4.hpp>
-
-#include <rinvid/core/rinvid_gfx.h>
-#include <rinvid/util/color.h>
-#include <rinvid/util/vector2.h>
-
 namespace rinvid
 {
 
@@ -70,41 +64,11 @@ class Texture
     friend class Sprite;
 
     void release_gl_resources();
+    void bind() const;
 
-    /**************************************************************************************************
-     * @brief Internal function called by sprite. Draws part of texture specified by sprite calling
-     * it.
-     *
-     * @param transform Transformation to apply (model matrix)
-     * @param shader Shader to be used.
-     * @param opacity Transparency level (0.0 being invisible, 1.0 being fully visible).
-     *
-     *************************************************************************************************/
-    void draw(const glm::mat4& transform, const Shader shader, float opacity = 1.0F);
-
-    /**************************************************************************************************
-     * @brief Internal function called by sprite. Adjusts internal texture vertices based on
-     * arguments passed by sprite.
-     *
-     *************************************************************************************************/
-    void update_vertices(Vector2f offset, std::uint32_t width, std::uint32_t height);
-
-    std::int32_t width_{};
-    std::int32_t height_{};
-
-    // OpenGl object id's
-    std::uint32_t vertex_array_object_{};
-    std::uint32_t vertex_buffer_obecjt_{};
-    std::uint32_t element_buffer_object_{};
+    std::int32_t  width_{};
+    std::int32_t  height_{};
     std::uint32_t texture_id_{};
-
-    // There are four vertices with 5 elements each, elements are: x, y, z coordinate and x and y
-    // texture cooridnate, hence 4 * 5
-    float               gl_vertices_[4 * 5]{};
-    const std::uint32_t indices_[6] = {
-        0, 1, 3, // first triangle
-        1, 2, 3  // second triangle
-    };
 };
 
 } // namespace rinvid

--- a/tests/include/sprite_test.h
+++ b/tests/include/sprite_test.h
@@ -16,6 +16,7 @@
 
 #include <SFML/Window/Context.hpp>
 
+#include <rinvid/core/rinvid_gfx.h>
 #include <rinvid/core/rinvid_gl.h>
 #include <rinvid/core/texture.h>
 
@@ -50,8 +51,7 @@ class SpriteTest : public ::testing::Test
             GTEST_SKIP() << "Required OpenGL 3.0 functions are unavailable";
         }
 #endif
-        Application* application{nullptr};
-        RinvidGfx::init(application);
+        RinvidGfx::init(nullptr);
 
         const char* file_name = {"tests/resources/valid_image.png"};
         mock_texture_         = new Texture{file_name};
@@ -61,6 +61,7 @@ class SpriteTest : public ::testing::Test
     {
         delete mock_texture_;
         mock_texture_ = nullptr;
+        RinvidGfx::shutdown();
     }
 
     Texture* mock_texture_{nullptr};

--- a/tests/sprite_test.cpp
+++ b/tests/sprite_test.cpp
@@ -7,6 +7,8 @@
  * repository for more details.
  **********************************************************************/
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #include <rinvid/core/sprite.h>
@@ -15,6 +17,22 @@
 #include "include/sprite_test.h"
 
 using namespace rinvid;
+
+namespace
+{
+
+std::array<float, 20> read_bound_sprite_vertices()
+{
+    GLint vertex_buffer_object{};
+    GL_CALL(glGetVertexAttribiv(0, GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING, &vertex_buffer_object));
+
+    std::array<float, 20> vertices{};
+    GL_CALL(glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(vertex_buffer_object)));
+    GL_CALL(glGetBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices.data()));
+    return vertices;
+}
+
+} // namespace
 
 // Test default constructor
 TEST_F(SpriteTest, DefaultConstructor)
@@ -137,5 +155,26 @@ TEST_F(SpriteTest, AnimatedDraw_AdvancesAnimation)
 
     EXPECT_NO_THROW(sprite.draw(1.0));
     EXPECT_TRUE(sprite.get_animation().is_animation_finished());
+    ASSERT_TRUE(number_of_errors == errors::get_error_count());
+}
+
+TEST_F(SpriteTest, SharedTextureSpritesKeepIndependentGeometry)
+{
+    auto number_of_errors = errors::get_error_count();
+
+    Sprite sprite_1{mock_texture_, 100, 100, {10.0F, 20.0F}, {0.0F, 0.0F}};
+    Sprite sprite_2{mock_texture_, 64, 32, {200.0F, 100.0F}, {5.0F, 10.0F}};
+
+    sprite_1.draw();
+    const auto sprite_1_vertices_before = read_bound_sprite_vertices();
+
+    sprite_2.draw();
+    const auto sprite_2_vertices = read_bound_sprite_vertices();
+
+    sprite_1.draw();
+    const auto sprite_1_vertices_after = read_bound_sprite_vertices();
+
+    EXPECT_NE(sprite_1_vertices_before, sprite_2_vertices);
+    EXPECT_EQ(sprite_1_vertices_before, sprite_1_vertices_after);
     ASSERT_TRUE(number_of_errors == errors::get_error_count());
 }


### PR DESCRIPTION
This fixes a bug that would actually prevent using texture as a shared resource for multiple sprites.